### PR TITLE
注册回调函数事件错误问题。

### DIFF
--- a/api/CronClient.js
+++ b/api/CronClient.js
@@ -158,10 +158,7 @@ function publish(task){
  * @param method 任务需要回调的函数引用
  */
 function register(method){
-  if (method instanceof Object) {
-    return methods = Object.assign(methods, method);
-  }
-  if (method) {
+  if (method && typeof method === 'function') {
     methods[method.name] = method;
   }
 }


### PR DESCRIPTION
  if (method instanceof Object) {
    return methods = Object.assign(methods, method);
  }

这里用`method instanceof Object`来判断是否是一个对象，但是函数的的原型链也是指向对象的，导致这里直接就return一个继承后的对象，然而并不能继承一个函数，所以就报错了。
